### PR TITLE
Support Python 3.8+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,7 +34,12 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,tui]"
+          # Textual >=1.0 requires Python 3.9+; on 3.8 install without the tui extra.
+          if [[ "${{ matrix.python-version }}" == "3.8" ]]; then
+            pip install -e ".[dev]"
+          else
+            pip install -e ".[dev,tui]"
+          fi
 
       - name: Lint (ruff check)
         run: ruff check src/ tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,10 +93,11 @@ mypy src/klipperctl/
 
 ### Dependencies
 
+- **Python 3.8+** for the core CLI. The TUI requires Python 3.9+ (Textual ≥1.0 dropped 3.8).
 - `click>=8.1` — CLI framework (zero transitive deps)
 - `rich>=13.0` — Tables, colored output
 - `moonraker-client>=0.1.0` — Moonraker API client library (httpx + websockets)
-- Optional TUI: `textual>=1.0` — Terminal UI framework (install with `pip install klipperctl[tui]`)
+- Optional TUI: `textual>=1.0; python_version>='3.9'` — Terminal UI framework (install with `pip install klipperctl[tui]`). On Python 3.8 the extra resolves to nothing and `klipperctl tui` exits with the existing "textual not installed" ImportError guard.
 - Dev: `pytest`, `pytest-asyncio`, `ruff`, `mypy`
 
 ### Test Structure
@@ -133,7 +134,7 @@ mypy src/klipperctl/
 
 ### Workflows
 
-- `.github/workflows/ci.yml` — runs on every PR and push to `main`. Matrix across Python 3.10–3.13: `ruff check`, `ruff format --check`, `mypy`, `pytest tests/unit/`. Installs with `pip install -e ".[dev,tui]"` so Textual-dependent TUI tests run. Functional tests are not run in CI.
+- `.github/workflows/ci.yml` — runs on every PR and push to `main`. Matrix across Python 3.8–3.13: `ruff check`, `ruff format --check`, `mypy`, `pytest tests/unit/`. Installs with `pip install -e ".[dev,tui]"` on 3.9+ so Textual-dependent TUI tests run; on 3.8 installs `".[dev]"` only (Textual ≥1.0 requires 3.9+), and TUI test modules skip via `pytest.importorskip("textual")`. Functional tests are not run in CI.
 - `.github/workflows/release.yml` — triggered on `v*.*.*` tag push (and `workflow_dispatch` for TestPyPI-only dry-runs). Three jobs: `build` (sdist + wheel via `python -m build`) → `publish-testpypi` → `publish-pypi`. The PyPI job is gated on a tag ref, so manual dispatch can never reach prod PyPI.
 
 ### PyPI Trusted Publishing (OIDC — no API tokens)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ With TUI support (interactive terminal dashboard):
 pip install "klipperctl[tui]"
 ```
 
+**Requires Python 3.8+.** The TUI (`klipperctl[tui]`) additionally requires Python 3.9+
+(Textual ≥1.0 dropped 3.8 support); on Python 3.8 the core CLI works but `klipperctl tui`
+will exit with a message that `textual` is not installed.
+
 For development (sibling-checkout layout):
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "klipperctl"
-version = "0.1.0"
+version = "0.2.0"
 description = "Command line interface for 3D printers using Moonraker and Klipper"
 readme = "README.md"
 license = "GPL-3.0"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 authors = [
     { name = "Christopher Byrd" },
 ]
@@ -19,6 +19,8 @@ classifiers = [
     "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -28,7 +30,7 @@ classifiers = [
 dependencies = [
     "click>=8.1",
     "rich>=13.0",
-    "moonraker-client>=0.1.0",
+    "moonraker-client>=0.2.0",
     "tomli>=2.0; python_version<'3.11'",
 ]
 
@@ -40,7 +42,7 @@ dev = [
     "mypy>=1.13",
 ]
 tui = [
-    "textual>=1.0",
+    "textual>=1.0; python_version>='3.9'",
 ]
 
 [project.scripts]
@@ -61,7 +63,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py38"
 line-length = 99
 
 [tool.ruff.lint]
@@ -72,13 +74,24 @@ select = ["B", "C4", "E", "F", "I", "N", "RUF", "SIM", "UP", "W"]
 "src/klipperctl/tui/**" = ["RUF012"]
 
 [tool.mypy]
-python_version = "3.10"
+# mypy 1.14+ (last version supporting Python 3.8 at runtime) no longer
+# supports `python_version = "3.8"` as a target — its lowest is 3.9.
+# Package runtime still supports 3.8; 3.9 is close enough for type-check
+# semantics.
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = "tomli"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Textual is an optional dependency gated on Python 3.9+. On 3.8 (where we
+# still type-check the core CLI) mypy can't find the textual stubs; ignore
+# those imports rather than mypy-fail the whole run.
+module = "textual.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/klipperctl/__init__.py
+++ b/src/klipperctl/__init__.py
@@ -1,3 +1,3 @@
 """klipperctl - Command line interface for 3D printers using Moonraker and Klipper."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/klipperctl/tui/screens/commands.py
+++ b/src/klipperctl/tui/screens/commands.py
@@ -78,7 +78,7 @@ class CommandMenuScreen(Screen):
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         item_id = event.item.id or ""
-        group_key = item_id.removeprefix("group-")
+        group_key = item_id[len("group-") :] if item_id.startswith("group-") else item_id
         screen_map: dict[str, type[Screen]] = {
             "printer": PrinterCommandScreen,
             "print": PrintCommandScreen,
@@ -234,7 +234,7 @@ class _BaseCommandScreen(Screen):
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         item_id = event.item.id or ""
-        cmd_name = item_id.removeprefix("cmd-")
+        cmd_name = item_id[len("cmd-") :] if item_id.startswith("cmd-") else item_id
         self._run_command(cmd_name)
 
     def _run_command(self, cmd_name: str) -> None:
@@ -369,7 +369,7 @@ class SelectionScreen(ModalScreen[str]):
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         item_id = event.item.id or ""
-        idx_str = item_id.removeprefix("sel-")
+        idx_str = item_id[len("sel-") :] if item_id.startswith("sel-") else item_id
         try:
             idx = int(idx_str)
             value = self._items[idx][0]

--- a/tests/functional/_harness.py
+++ b/tests/functional/_harness.py
@@ -17,7 +17,7 @@ identical assertions. Runners re-use existing code wherever possible:
 
 All runner methods are ``async`` because the TUI modality must drive a
 live Textual Pilot, and Pilot operations must be awaited. The library
-and CLI runners wrap their sync calls in ``asyncio.to_thread`` so the
+and CLI runners wrap their sync calls in ``_to_thread`` so the
 three modalities share an identical async signature and tests can be
 written once against the abstract interface.
 """
@@ -25,13 +25,25 @@ written once against the abstract interface.
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
+import sys
 import time
 import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from click.testing import CliRunner
+
+if sys.version_info >= (3, 9):
+    _to_thread = asyncio.to_thread
+else:
+    # ``asyncio.to_thread`` is 3.9+. Provide a small backport for the
+    # functional test harness when running on Python 3.8.
+    async def _to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, functools.partial(func, *args, **kwargs))
+
 
 if TYPE_CHECKING:
     from moonraker_client import MoonrakerClient
@@ -198,17 +210,17 @@ class LibraryRunner(WorkflowRunner):
         def _call() -> str:
             return _read_print_state(self._client)
 
-        return await asyncio.to_thread(_call)
+        return await _to_thread(_call)
 
     async def set_hotend_temp(self, target: float) -> None:
         from moonraker_client.helpers import set_hotend_temp
 
-        await asyncio.to_thread(set_hotend_temp, self._client, target)
+        await _to_thread(set_hotend_temp, self._client, target)
 
     async def set_bed_temp(self, target: float) -> None:
         from moonraker_client.helpers import set_bed_temp
 
-        await asyncio.to_thread(set_bed_temp, self._client, target)
+        await _to_thread(set_bed_temp, self._client, target)
 
     async def get_hotend_target(self) -> float:
         from moonraker_client.helpers import get_temperatures
@@ -217,14 +229,14 @@ class LibraryRunner(WorkflowRunner):
             reading = get_temperatures(self._client).get("extruder")
             return float(reading.target) if reading else 0.0
 
-        return await asyncio.to_thread(_call)
+        return await _to_thread(_call)
 
     async def wait_until_temp(
         self, heater: str, target: float, tol: float = 3.0, timeout: float = 180.0
     ) -> bool:
         from moonraker_client.helpers import wait_for_temps
 
-        return await asyncio.to_thread(
+        return await _to_thread(
             wait_for_temps,
             self._client,
             {heater: target},
@@ -234,25 +246,25 @@ class LibraryRunner(WorkflowRunner):
         )
 
     async def upload_sentinel_gcode(self) -> str:
-        return await asyncio.to_thread(_upload_sentinel, self._client)
+        return await _to_thread(_upload_sentinel, self._client)
 
     async def start_print(self, filename: str) -> None:
         from moonraker_client.helpers import start_print
 
-        await asyncio.to_thread(start_print, self._client, filename)
+        await _to_thread(start_print, self._client, filename)
 
     async def cancel_print(self) -> None:
-        await asyncio.to_thread(self._client.print_cancel)
+        await _to_thread(self._client.print_cancel)
 
     async def send_gcode(self, command: str) -> None:
         from moonraker_client.helpers import send_gcode
 
-        await asyncio.to_thread(send_gcode, self._client, command)
+        await _to_thread(send_gcode, self._client, command)
 
     async def tail_logs_for(self, marker: str, timeout: float = 10.0) -> bool:
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            found = await asyncio.to_thread(_scan_gcode_store_for, self._client, marker)
+            found = await _to_thread(_scan_gcode_store_for, self._client, marker)
             if found:
                 return True
             await asyncio.sleep(0.5)
@@ -281,7 +293,14 @@ class CliModalityRunner(WorkflowRunner):
             cli_args.append("--json")
         cli_args.extend(args)
         result = self._runner.invoke(cli, cli_args)
-        return result.exit_code, result.output or "", result.stderr or ""
+        # click 8.1 (Python 3.8 floor) raises ValueError on result.stderr
+        # when mix_stderr defaults to True. Fall back to stderr_bytes.
+        try:
+            stderr = result.stderr or ""
+        except ValueError:
+            stderr_bytes = getattr(result, "stderr_bytes", None) or b""
+            stderr = stderr_bytes.decode("utf-8", errors="replace")
+        return result.exit_code, result.output or "", stderr
 
     def _invoke_json_sync(self, *args: str) -> object:
         code, out, err = self._invoke(*args, json_output=True)
@@ -290,7 +309,7 @@ class CliModalityRunner(WorkflowRunner):
         return json.loads(out)
 
     async def _invoke_json(self, *args: str) -> object:
-        return await asyncio.to_thread(self._invoke_json_sync, *args)
+        return await _to_thread(self._invoke_json_sync, *args)
 
     async def _invoke_ok(self, *args: str) -> None:
         def _run() -> None:
@@ -298,7 +317,7 @@ class CliModalityRunner(WorkflowRunner):
             if code != 0:
                 raise RuntimeError(f"CLI {' '.join(args)} failed: {err}")
 
-        await asyncio.to_thread(_run)
+        await _to_thread(_run)
 
     async def get_state(self) -> str:
         # `klipperctl printer status` surfaces the *klippy* state (stays
@@ -313,7 +332,7 @@ class CliModalityRunner(WorkflowRunner):
             with MoonrakerClient(base_url=self._url, timeout=15.0) as c:
                 return _read_print_state(c)
 
-        return await asyncio.to_thread(_call)
+        return await _to_thread(_call)
 
     async def set_hotend_temp(self, target: float) -> None:
         await self._invoke_ok("printer", "set-temp", "--hotend", str(target))
@@ -354,7 +373,7 @@ class CliModalityRunner(WorkflowRunner):
             with MoonrakerClient(base_url=self._url, timeout=15.0) as c:
                 return _upload_sentinel(c)
 
-        return await asyncio.to_thread(_do)
+        return await _to_thread(_do)
 
     async def start_print(self, filename: str) -> None:
         await self._invoke_ok("print", "start", filename)
@@ -374,7 +393,7 @@ class CliModalityRunner(WorkflowRunner):
 
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            if await asyncio.to_thread(_scan_once):
+            if await _to_thread(_scan_once):
                 return True
             await asyncio.sleep(0.5)
         return False
@@ -428,7 +447,7 @@ class TuiRunner(WorkflowRunner):
             with self._lib_client() as c:
                 return _read_print_state(c)
 
-        return await asyncio.to_thread(_call)
+        return await _to_thread(_call)
 
     async def set_hotend_temp(self, target: float) -> None:
         await self._run_cli_via_tui(["printer", "set-temp", "--hotend", str(target)])
@@ -444,7 +463,7 @@ class TuiRunner(WorkflowRunner):
                 reading = get_temperatures(c).get("extruder")
                 return float(reading.target) if reading else 0.0
 
-        return await asyncio.to_thread(_call)
+        return await _to_thread(_call)
 
     async def wait_until_temp(
         self, heater: str, target: float, tol: float = 3.0, timeout: float = 180.0
@@ -461,14 +480,14 @@ class TuiRunner(WorkflowRunner):
                     poll_interval=2.0,
                 )
 
-        return await asyncio.to_thread(_call)
+        return await _to_thread(_call)
 
     async def upload_sentinel_gcode(self) -> str:
         def _do() -> str:
             with self._lib_client() as c:
                 return _upload_sentinel(c)
 
-        return await asyncio.to_thread(_do)
+        return await _to_thread(_do)
 
     async def start_print(self, filename: str) -> None:
         await self._run_cli_via_tui(["print", "start", filename])
@@ -490,7 +509,7 @@ class TuiRunner(WorkflowRunner):
 
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            if await asyncio.to_thread(_scan_once):
+            if await _to_thread(_scan_once):
                 return True
             await asyncio.sleep(0.5)
         return False

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -174,6 +174,7 @@ async def workflow_runner(
     elif modality == "cli":
         yield CliModalityRunner(moonraker_url)
     elif modality == "tui":
+        pytest.importorskip("textual")
         from klipperctl.tui.app import KlipperApp
 
         app = KlipperApp(printer_url=moonraker_url, poll_interval=1.0)

--- a/tests/functional/test_file_transfers.py
+++ b/tests/functional/test_file_transfers.py
@@ -168,8 +168,7 @@ async def test_cli_upload_and_download_roundtrip(
         assert local_dst.exists()
         assert local_dst.read_bytes() == PAYLOAD
     finally:
-        with (
-            contextlib.suppress(Exception),
-            MoonrakerClient(base_url=moonraker_url, timeout=15.0) as client,
-        ):
+        with contextlib.suppress(Exception), MoonrakerClient(
+            base_url=moonraker_url, timeout=15.0
+        ) as client:
             client.files_delete("gcodes", filename)

--- a/tests/functional/test_tui.py
+++ b/tests/functional/test_tui.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytest.importorskip("textual")
+
 MOONRAKER_URL = os.environ.get("MOONRAKER_URL", "http://localhost:7125")
 
 

--- a/tests/functional/test_tui_dashboard_console.py
+++ b/tests/functional/test_tui_dashboard_console.py
@@ -25,6 +25,8 @@ import uuid
 
 import pytest
 
+pytest.importorskip("textual")
+
 pytestmark = [pytest.mark.functional, pytest.mark.asyncio]
 
 
@@ -370,8 +372,7 @@ async def test_dashboard_console_error_path(moonraker_url: str, printer_ready: b
         from moonraker_client import MoonrakerClient
         from moonraker_client.helpers import set_hotend_temp
 
-        with (
-            contextlib.suppress(Exception),
-            MoonrakerClient(base_url=moonraker_url, timeout=15.0) as client,
-        ):
+        with contextlib.suppress(Exception), MoonrakerClient(
+            base_url=moonraker_url, timeout=15.0
+        ) as client:
             set_hotend_temp(client, 0.0)

--- a/tests/functional/test_tui_full_console.py
+++ b/tests/functional/test_tui_full_console.py
@@ -22,6 +22,8 @@ import uuid
 
 import pytest
 
+pytest.importorskip("textual")
+
 pytestmark = [pytest.mark.functional, pytest.mark.asyncio]
 
 

--- a/tests/functional/test_tui_heater_chart.py
+++ b/tests/functional/test_tui_heater_chart.py
@@ -22,6 +22,8 @@ import contextlib
 
 import pytest
 
+pytest.importorskip("textual")
+
 pytestmark = [pytest.mark.functional, pytest.mark.asyncio]
 
 
@@ -120,10 +122,9 @@ async def test_setting_hotend_target_reflects_in_chart(
             )
     finally:
         # Cool down so the next test starts from a clean baseline.
-        with (
-            contextlib.suppress(Exception),
-            MoonrakerClient(base_url=moonraker_url, timeout=15.0) as client,
-        ):
+        with contextlib.suppress(Exception), MoonrakerClient(
+            base_url=moonraker_url, timeout=15.0
+        ) as client:
             set_hotend_temp(client, 0.0)
 
 

--- a/tests/functional/test_workflows.py
+++ b/tests/functional/test_workflows.py
@@ -143,17 +143,15 @@ async def _ensure_not_printing(  # type: ignore[no-untyped-def]
         state = await runner.get_state()
         if state in ACTIVELY_PRINTING_STATES:
             # Soft cleanup didn't take; hard-reset the firmware.
-            with (
-                contextlib.suppress(Exception),
-                MoonrakerClient(base_url=moonraker_url, timeout=15.0) as client,
-            ):
+            with contextlib.suppress(Exception), MoonrakerClient(
+                base_url=moonraker_url, timeout=15.0
+            ) as client:
                 restart_firmware(client, timeout=timeout, poll_interval=2.0)
 
     # Also recover from Klippy shutdown (MCU timer errors, etc).
-    with (
-        contextlib.suppress(Exception),
-        MoonrakerClient(base_url=moonraker_url, timeout=15.0) as client,
-    ):
+    with contextlib.suppress(Exception), MoonrakerClient(
+        base_url=moonraker_url, timeout=15.0
+    ) as client:
         status = get_printer_status(client)
         if status.klippy_state != "ready":
             restart_firmware(client, timeout=timeout, poll_interval=2.0)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -23,10 +23,12 @@ class TestCLI:
         assert "klipperctl" in result.output.lower() or "Command line" in result.output
 
     def test_version(self) -> None:
+        from klipperctl import __version__
+
         runner = CliRunner()
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert __version__ in result.output
 
     def test_printer_group_help(self) -> None:
         runner = CliRunner()
@@ -139,7 +141,11 @@ class TestErrorHandling:
         with patch("klipperctl.client.build_client", return_value=client):
             result = runner.invoke(cli, ["print", "start", "missing.gcode"])
         assert result.exit_code == 3
-        assert "missing.gcode" in (result.stderr + result.output)
+        # click 8.1 (Python 3.8 floor) merges stderr into output by default
+        # and raises on result.stderr access; click 8.2+ separates them.
+        stderr_bytes = getattr(result, "stderr_bytes", None) or b""
+        combined = result.output + stderr_bytes.decode("utf-8", errors="replace")
+        assert "missing.gcode" in combined
 
     def test_stray_file_not_found_is_not_user_input(self) -> None:
         """A FileNotFoundError from an unrelated path is *not* mapped to exit 3.

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("textual")
+
 from klipperctl.tui.app import KlipperApp
 
 

--- a/tests/unit/test_tui_cmd.py
+++ b/tests/unit/test_tui_cmd.py
@@ -6,6 +6,7 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from klipperctl.cli import cli
@@ -39,6 +40,7 @@ class TestTuiCommand:
         assert "--printer" in result.output
 
     def test_tui_resolves_config_printer(self) -> None:
+        pytest.importorskip("textual")
         runner = CliRunner()
         mock_config = {
             "default_printer": "myprinter",
@@ -49,10 +51,9 @@ class TestTuiCommand:
                 },
             },
         }
-        with (
-            patch("klipperctl.commands.tui_cmd.load_config", return_value=mock_config),
-            patch("klipperctl.tui.app.KlipperApp") as mock_app_cls,
-        ):
+        with patch("klipperctl.commands.tui_cmd.load_config", return_value=mock_config), patch(
+            "klipperctl.tui.app.KlipperApp"
+        ) as mock_app_cls:
             mock_app = MagicMock()
             mock_app_cls.return_value = mock_app
             runner.invoke(cli, ["tui", "--printer", "myprinter"])
@@ -64,11 +65,11 @@ class TestTuiCommand:
             mock_app.run.assert_called_once()
 
     def test_tui_uses_global_url(self) -> None:
+        pytest.importorskip("textual")
         runner = CliRunner()
-        with (
-            patch("klipperctl.commands.tui_cmd.load_config", return_value={}),
-            patch("klipperctl.tui.app.KlipperApp") as mock_app_cls,
-        ):
+        with patch("klipperctl.commands.tui_cmd.load_config", return_value={}), patch(
+            "klipperctl.tui.app.KlipperApp"
+        ) as mock_app_cls:
             mock_app = MagicMock()
             mock_app_cls.return_value = mock_app
             runner.invoke(cli, ["--url", "http://flag:7125", "tui"])
@@ -77,12 +78,11 @@ class TestTuiCommand:
             assert call_kwargs["printer_url"] == "http://flag:7125"
 
     def test_tui_uses_env_url(self) -> None:
+        pytest.importorskip("textual")
         runner = CliRunner()
-        with (
-            patch("klipperctl.commands.tui_cmd.load_config", return_value={}),
-            patch("klipperctl.tui.app.KlipperApp") as mock_app_cls,
-            patch.dict("os.environ", {"MOONRAKER_URL": "http://env:7125"}),
-        ):
+        with patch("klipperctl.commands.tui_cmd.load_config", return_value={}), patch(
+            "klipperctl.tui.app.KlipperApp"
+        ) as mock_app_cls, patch.dict("os.environ", {"MOONRAKER_URL": "http://env:7125"}):
             mock_app = MagicMock()
             mock_app_cls.return_value = mock_app
             runner.invoke(cli, ["tui"])
@@ -90,15 +90,14 @@ class TestTuiCommand:
             assert call_kwargs["printer_url"] == "http://env:7125"
 
     def test_tui_default_url(self) -> None:
+        pytest.importorskip("textual")
         runner = CliRunner()
         env = os.environ.copy()
         env.pop("MOONRAKER_URL", None)
         env.pop("MOONRAKER_API_KEY", None)
-        with (
-            patch("klipperctl.commands.tui_cmd.load_config", return_value={}),
-            patch("klipperctl.tui.app.KlipperApp") as mock_app_cls,
-            patch.dict("os.environ", env, clear=True),
-        ):
+        with patch("klipperctl.commands.tui_cmd.load_config", return_value={}), patch(
+            "klipperctl.tui.app.KlipperApp"
+        ) as mock_app_cls, patch.dict("os.environ", env, clear=True):
             mock_app = MagicMock()
             mock_app_cls.return_value = mock_app
             runner.invoke(cli, ["tui"])

--- a/tests/unit/test_tui_command_screens.py
+++ b/tests/unit/test_tui_command_screens.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("textual")
+
 from klipperctl.tui.app import KlipperApp
 
 

--- a/tests/unit/test_tui_screens.py
+++ b/tests/unit/test_tui_screens.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("textual")
+
 from klipperctl.tui.app import KlipperApp
 
 

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("textual")
+
 from klipperctl.tui.widgets.temperatures import _friendly_name
 
 


### PR DESCRIPTION
## Summary

- Widen `requires-python` from `>=3.10` to `>=3.8` for the core CLI, paired with the sibling [moonraker-client v0.2.0](https://pypi.org/project/moonraker-client/0.2.0/) release which gained its own 3.8 support.
- TUI gated on Python 3.9+ via a PEP 508 env marker (`textual>=1.0; python_version>='3.9'`) — Textual 1.x dropped 3.8 and rolling back is infeasible. On 3.8, `pip install klipperctl[tui]` resolves to nothing and `klipperctl tui` hits the existing "textual not installed" ImportError path.
- Three `str.removeprefix()` (3.9+) calls in `tui/screens/commands.py` replaced with `startswith`-guarded slicing.
- Test suite fixes (uncovered by actually running on 3.8):
  - `asyncio.to_thread` backport shim in `tests/functional/_harness.py` (swept all 24 usages).
  - PEP 617 parenthesized `with (...)` statements rewritten to the 3.8-compatible comma form across 5 test files.
  - `test_cli.py` version assertion pulls from `klipperctl.__version__`; stderr access hardened against click 8.1's default `mix_stderr=True` (falls back to `result.stderr_bytes`).
  - All `test_tui*.py` modules guarded with `pytest.importorskip("textual")`; TUI tests in `test_tui_cmd.py` that patch `klipperctl.tui.app.KlipperApp` get per-test `importorskip`, keeping the textual-not-installed tests runnable on 3.8.
  - `workflow_runner[tui]` fixture parametrize branch also `importorskip`s textual.
- Metadata/tooling: ruff `target-version = "py38"`, mypy `python_version = "3.9"` (mypy 1.14+ can't target 3.8), classifiers extended, CI matrix extended to 3.8-3.13 with a conditional install step that skips the `tui` extra on 3.8. Version bumped to 0.2.0.
- README + CLAUDE.md note the 3.8 core / 3.9 TUI split.

## Test plan

- [x] `ruff check src/ tests/` clean on 3.8 and 3.12
- [x] `ruff format --check` clean on both
- [x] `mypy src/klipperctl/` clean on both
- [x] `pytest tests/unit/` — 171 pass + 9 skipped on 3.8 (TUI modules skip via importorskip); 318 pass + 1 skip on 3.12
- [x] `MOONRAKER_URL=... pytest tests/functional/ --functional` — 51 pass + 5 skipped on 3.8 against the live virtual printer (TUI functional tests not collected); 74 pass on 3.12 (full TUI included)
- [ ] CI matrix green across 3.8 – 3.13 (this PR)
- [ ] Post-release 3.8 smoke install from PyPI